### PR TITLE
Add basic HTTP tests and enable npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "lean_presenter_app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js 8080"
   },
   "keywords": [],

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const { setTimeout: delay } = require('node:timers/promises');
+
+const PORT = 8123;
+let serverProcess;
+
+test.before(async () => {
+  serverProcess = spawn('node', ['server.js', PORT], {
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  // give the server a moment to start
+  await delay(500);
+});
+
+test.after(() => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+});
+
+test('serves index.html', async () => {
+  const res = await fetch(`http://localhost:${PORT}/`);
+  assert.strictEqual(res.status, 200);
+  const body = await res.text();
+  assert.match(body, /Lean Training/);
+});
+
+test('redirects short join URL', async () => {
+  const res = await fetch(`http://localhost:${PORT}/j/testroom`, { redirect: 'manual' });
+  assert.strictEqual(res.status, 302);
+  assert.strictEqual(res.headers.get('location'), '/?room=testroom&role=client');
+});
+
+test('QR endpoint returns SVG', async () => {
+  const res = await fetch(`http://localhost:${PORT}/qr.svg?text=hello`);
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.headers.get('content-type'), 'image/svg+xml; charset=utf-8');
+  const body = await res.text();
+  assert.ok(body.includes('<svg'));
+});


### PR DESCRIPTION
## Summary
- enable `node --test` via npm test
- add basic server tests for index, join redirect, and QR endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac68488e1883329022bf804196d8a2