### PR TITLE
Fix whiteboard toolbar visibility and drawing toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -335,6 +335,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
   drawEnabled = on;
   document.body.classList.toggle('ink-on', on);
   document.body.classList.toggle('wb-open', on);
+  if(panel) panel.style.display = on ? 'block' : 'none';
   if(fab) fab.classList.toggle('active', on);
   if(wbInd) wbInd.classList.toggle('on', on);
   page.classList.toggle('highlight-draw', on);

--- a/style.css
+++ b/style.css
@@ -115,6 +115,7 @@ pre{white-space:pre-wrap;word-wrap:break-word}
 .fab:hover{transform:translateY(-1px)}
 .fab.active{background:#1b3e5c;border-color:#2e5c84}
 .wb-panel{position:fixed;right:18px;bottom:82px;z-index:1001;background:#0e1824;border:1px solid #22364c;border-radius:14px;padding:10px;display:none;min-width:260px;box-shadow:0 18px 36px rgba(0,0,0,.5);backdrop-filter:blur(6px)}
+.wb-open .wb-panel{display:block}
 .wb-panel .row{gap:8px}
 .wb-panel label{font-size:12px;color:#b9c7d6}
 .color-swatch{width:28px;height:28px;border-radius:999px;border:2px solid #274b6b;box-shadow:0 2px 8px rgba(0,0,0,.4);cursor:pointer}


### PR DESCRIPTION
## Summary
- Show whiteboard toolbar when writing mode is enabled
- Toggle toolbar display directly from draw mode switch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac7191074c83328f296ba9a74ef91f