### PR TITLE
Ensure saved poll Start button triggers poll

### DIFF
--- a/savedPolls.js
+++ b/savedPolls.js
@@ -21,10 +21,20 @@
       `<button data-i="${i}" class="delete pill danger mini">Delete</button></div>`
     ).join('');
     container.querySelectorAll('button.start').forEach(btn=>{
-      btn.onclick = ()=>{ const poll=polls[Number(btn.dataset.i)]; startCb && startCb(poll); };
+      btn.addEventListener('click', (ev)=>{
+        ev.preventDefault();
+        const poll = polls[Number(btn.dataset.i)];
+        if(startCb) startCb(poll);
+      });
     });
     container.querySelectorAll('button.delete').forEach(btn=>{
-      btn.onclick = ()=>{ const idx=Number(btn.dataset.i); polls.splice(idx,1); localStorage.setItem('savedPolls', JSON.stringify(polls)); renderSavedPolls(container,startCb); };
+      btn.addEventListener('click', (ev)=>{
+        ev.preventDefault();
+        const idx = Number(btn.dataset.i);
+        polls.splice(idx,1);
+        localStorage.setItem('savedPolls', JSON.stringify(polls));
+        renderSavedPolls(container,startCb);
+      });
     });
   }
   global.SavedPolls = { loadSavedPolls, savePoll, renderSavedPolls };

--- a/tests/savedpolls.test.js
+++ b/tests/savedpolls.test.js
@@ -22,3 +22,48 @@ test('saved polls save and load from localStorage', () => {
   assert.strictEqual(arr.length, 1);
   assert.strictEqual(arr[0].q, 'Example?');
 });
+
+test('renderSavedPolls calls start callback', () => {
+  const store = {};
+  global.localStorage = {
+    getItem: k => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    clear: () => { for (const k in store) delete store[k]; }
+  };
+  const SavedPolls = require('../savedPolls.js');
+  localStorage.clear();
+  SavedPolls.savePoll({ id: '1', q: 'Example?', type: 'tf' });
+
+  const container = {
+    _html: '',
+    buttons: [],
+    set innerHTML(html) {
+      this._html = html;
+      this.buttons = [];
+      const regex = /<button data-i="(\d+)" class="([^"]+)">/g;
+      let m;
+      while ((m = regex.exec(html))) {
+        const idx = m[1]; const cls = m[2];
+        const btn = {
+          dataset: { i: idx },
+          className: cls,
+          handlers: {},
+          addEventListener(type, fn) { this.handlers[type] = fn; },
+          click() { this.handlers.click && this.handlers.click({ preventDefault() {} }); }
+        };
+        this.buttons.push(btn);
+      }
+    },
+    get innerHTML() { return this._html; },
+    querySelectorAll(sel) {
+      if (sel === 'button.start') return this.buttons.filter(b => b.className.includes('start'));
+      if (sel === 'button.delete') return this.buttons.filter(b => b.className.includes('delete'));
+      return [];
+    }
+  };
+
+  let started = false;
+  SavedPolls.renderSavedPolls(container, () => { started = true; });
+  container.querySelectorAll('button.start')[0].click();
+  assert.strictEqual(started, true);
+});


### PR DESCRIPTION
## Summary
- fix saved poll Start button by binding click events with addEventListener and preventDefault
- add regression test ensuring Start calls provided callback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca1d5dc6883329774c4f76c14ace0