### PR TITLE
Refine client join flow and header

### DIFF
--- a/app.js
+++ b/app.js
@@ -385,9 +385,51 @@ function setRoster(list){ USED_AVATARS = new Set(list||[]); renderAvatars(); }
 function updatePreview(){ const el=$('#preview'); if(!el) return; if(!AVATAR){ el.innerHTML='<span class="muted">Pick an avatar</span>'; return; } if(!NAME) NAME = genCodeName(AVATAR); el.innerHTML=`<span class="emoji">${AVATAR}</span><span class="chip">${NAME}</span>`; }
 function renderAvatars(){ const wrap = $('#avatarPick'); if(!wrap) return; wrap.innerHTML = AVATARS.map(a=>{ const taken = USED_AVATARS.has(a); return `<button class="pill ghost" data-av="${a}" style="opacity:${taken?0.35:1}" ${taken?'disabled':''}>${a}</button>`; }).join(''); $$('#avatarPick button').forEach(b=>{ if(b.dataset.av===AVATAR) b.classList.add('active'); b.onclick=()=>{ if(b.disabled) return; AVATAR = b.dataset.av; NAME = genCodeName(AVATAR); localStorage.setItem('avatar', AVATAR); $$('#avatarPick button').forEach(x=>x.classList.remove('active')); b.classList.add('active'); updatePreview(); toast('Avatar selected'); }; }); updatePreview(); }
 renderAvatars();
-function showJoinUI(){ $('#joinForm').style.display='flex'; $('#youAre').style.display='none'; const ch=$('#clientHeader'); if(ch){ ch.textContent='Join'; ch.style.display='block'; } $('#clientArea').style.display='none'; $('#reactRow').style.display='none'; $('#qaForm').classList.add('hidden'); updatePreview(); }
-function hideJoinUI(){ $('#joinForm').style.display='none'; $('#youAre').style.display='flex'; const ch=$('#clientHeader'); if(ch){ ch.style.display='none'; } $('#clientArea').style.display='block'; $('#reactRow').style.display='flex'; $('#qaForm').classList.add('hidden'); }
-function updateYouAre(){ const el=$('#youAre'); if(!el) return; el.innerHTML=`You are: <span style="font-size:18px">${AVATAR||'🙂'}</span> <span class="chip">${NAME||''}</span>`; }
+function showJoinUI(){
+  $('#joinForm').style.display='flex';
+  $('#youAre').style.display='none';
+  const ch=$('#clientHeader');
+  if(ch){ ch.textContent='Join'; ch.style.display='block'; }
+  $('#clientArea').style.display='none';
+  $('#reactRow').style.display='none';
+  $('#qaForm').classList.add('hidden');
+  $('#qaBtn')?.classList.add('hidden');
+  updatePreview();
+  updateHeader();
+}
+function hideJoinUI(){
+  $('#joinForm').style.display='none';
+  $('#youAre').style.display='flex';
+  const ch=$('#clientHeader');
+  if(ch){ ch.style.display='none'; }
+  $('#clientArea').style.display='block';
+  $('#reactRow').style.display='flex';
+  $('#qaForm').classList.add('hidden');
+  $('#qaBtn')?.classList.remove('hidden');
+  updateHeader();
+}
+function updateYouAre(){
+  const el=$('#youAre');
+  if(!el) return;
+  el.innerHTML=`You are: <span class="you-emoji">${AVATAR||'🙂'}</span> <span class="you-name">${NAME||''}</span>`;
+}
+function updateHeader(){
+  const user=$('#headerClient');
+  const h1=$('#hostTitle');
+  const room=$('#roomBadge');
+  if(ROLE==='client' && localStorage.getItem('joined')==='1'){
+    if(user){
+      user.innerHTML=`<span class="emoji">${AVATAR||'🙂'}</span><span class="name">${NAME||''}</span><span class="chip mono">${ROOM}</span>`;
+      user.classList.remove('hidden');
+    }
+    if(h1) h1.style.display='none';
+    if(room) room.style.display='none';
+  } else {
+    if(user) user.classList.add('hidden');
+    if(h1) h1.style.display='';
+    if(room) room.style.display='';
+  }
+}
 
 // Sticky join for clients
 (function(){ const wasJoined = localStorage.getItem('joined')==='1'; if (ROLE==='client' && wasJoined){ AVATAR = localStorage.getItem('avatar') || '🙂'; NAME = localStorage.getItem('name') || genCodeName(AVATAR); CLIENT_ID = localStorage.getItem('clientId') || CLIENT_ID; hideJoinUI(); updateYouAre(); }})();

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
 <div class="wrap">
   <header>
     <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 17c5-1 11-1 16 0" stroke="#7cd992" stroke-width="1.6" stroke-linecap="round"/><path d="M4 13c3-1 13-1 16 0" stroke="#58c4dc" stroke-width="1.6" stroke-linecap="round"/><path d="M4 9c2-1 7-1 10 0" stroke="#ffb86b" stroke-width="1.6" stroke-linecap="round"/><circle cx="6" cy="9" r="1.8" fill="#ffb86b"/><circle cx="12" cy="13" r="1.8" fill="#58c4dc"/><circle cx="18" cy="17" r="1.8" fill="#7cd992"/></svg>
-    <h1>Lean Training — Live Session</h1>
-    <span class="badge">QR join only • Local network • Pages + Whiteboard</span>
-    <div class="right row mini muted">Room: <span id="roomId" class="chip mono">auto</span></div>
+    <h1 id="hostTitle">Lean Training — Live Session</h1>
+    <div id="headerClient" class="header-user hidden"></div>
+    <div id="roomBadge" class="right row mini muted">Room: <span id="roomId" class="chip mono">auto</span></div>
   </header>
 
   <main>

--- a/style.css
+++ b/style.css
@@ -19,6 +19,9 @@ footer{padding:10px 0 18px}
 header{display:flex;align-items:center;gap:16px;padding:14px 18px;border-bottom:1px solid #1e2a39;background:linear-gradient(180deg,#0f1622,#0c111a)}
 header h1{font-size:18px;margin:0;letter-spacing:.3px}
 header .badge{font-size:12px;background:var(--chip);padding:4px 8px;border-radius:999px;color:var(--muted)}
+.header-user{display:flex;align-items:center;gap:8px;font-size:20px}
+.header-user .emoji{font-size:28px}
+.header-user .name{font-weight:600;font-size:20px}
 
 /* Layout */
 main{padding:18px;display:grid;gap:18px}
@@ -78,6 +81,8 @@ button:hover{opacity:.95}
 
 /* Chips & lists */
 .chip{background:var(--chip);border:1px solid #243349;border-radius:999px;padding:4px 8px;font-size:12px;color:#cfd9e3}
+.you-emoji{font-size:24px}
+.you-name{font-size:18px;font-weight:600}
 
 /* Table */
 .leader{width:100%;border-collapse:separate;border-spacing:0 8px}


### PR DESCRIPTION
## Summary
- Hide "Ask a question" button until after a participant joins
- Simplify header and show joined participant's emoji, name, and room
- Increase size of displayed emoji and name for better visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b14d1831cc83329a0b5278426e33ba