### PR TITLE
Add reaction bubbles and simplify client header

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,8 +236,6 @@
 <section id="clientCard" class="card hidden">
   <h2 id="clientHeader">Join</h2>
 
-  <div class="row mini gap8 mb8 hidden" id="youAre"></div>
-
   <div id="joinForm">
     <div id="joinPreview" class="row gap12 mb8">
       <div id="preview" class="row gap8"></div>

--- a/style.css
+++ b/style.css
@@ -81,8 +81,6 @@ button:hover{opacity:.95}
 
 /* Chips & lists */
 .chip{background:var(--chip);border:1px solid #243349;border-radius:999px;padding:4px 8px;font-size:12px;color:#cfd9e3}
-.you-emoji{font-size:24px}
-.you-name{font-size:18px;font-weight:600}
 
 /* Table */
 .leader{width:100%;border-collapse:separate;border-spacing:0 8px}
@@ -92,6 +90,10 @@ button:hover{opacity:.95}
 
 /* Toast */
 .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:#102030;border:1px solid #234;box-shadow:0 10px 30px rgba(0,0,0,.35);color:#cfe7ff;padding:10px 14px;border-radius:12px;display:none;z-index:2000}
+
+/* Reaction bubbles */
+.reaction-bubble{position:fixed;bottom:10px;font-size:32px;pointer-events:none;animation:react-bubble 2s ease-out forwards;z-index:1500}
+@keyframes react-bubble{from{transform:translateY(0) scale(1);opacity:.9}to{transform:translateY(-160px) scale(1.4);opacity:0}}
 
 /* Progress */
 .progress{height:8px;background:#142030;border:1px solid #223447;border-radius:999px;overflow:hidden}


### PR DESCRIPTION
## Summary
- Remove redundant "You are" line from client join view
- Show floating reaction emojis on presenter screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1576ec0088332ab866d9c83db710c