### PR TITLE
Refine floating reaction emoji animation

### DIFF
--- a/app.js
+++ b/app.js
@@ -359,8 +359,9 @@ function showReactionBubble(emoji){
   b.textContent=emoji;
   const max=Math.max(0,window.innerWidth-40);
   b.style.left=Math.floor(Math.random()*max)+'px';
+  b.style.setProperty('--shift',(Math.random()*120-60)+'px');
   document.body.appendChild(b);
-  setTimeout(()=>b.remove(),2000);
+  setTimeout(()=>b.remove(),5000);
 }
 
 // ---------- Q&A (host) ----------

--- a/style.css
+++ b/style.css
@@ -92,8 +92,14 @@ button:hover{opacity:.95}
 .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:#102030;border:1px solid #234;box-shadow:0 10px 30px rgba(0,0,0,.35);color:#cfe7ff;padding:10px 14px;border-radius:12px;display:none;z-index:2000}
 
 /* Reaction bubbles */
-.reaction-bubble{position:fixed;bottom:10px;font-size:32px;pointer-events:none;animation:react-bubble 2s ease-out forwards;z-index:1500}
-@keyframes react-bubble{from{transform:translateY(0) scale(1);opacity:.9}to{transform:translateY(-160px) scale(1.4);opacity:0}}
+.reaction-bubble{position:fixed;bottom:10px;font-size:32px;pointer-events:none;animation:react-bubble 5s ease-out forwards;z-index:1500}
+@keyframes react-bubble{
+  0%{transform:translate(0,0) scale(1);opacity:.9}
+  25%{transform:translate(var(--shift), -25vh) scale(1.1)}
+  50%{transform:translate(calc(var(--shift) * -1), -50vh) scale(1.2)}
+  75%{transform:translate(var(--shift), -75vh) scale(1.3)}
+  100%{transform:translate(calc(var(--shift) * -1), -100vh) scale(1.4);opacity:0}
+}
 
 /* Progress */
 .progress{height:8px;background:#142030;border:1px solid #223447;border-radius:999px;overflow:hidden}


### PR DESCRIPTION
## Summary
- Extend reaction bubble animation to float to the top with zig-zag motion
- Keep reactions visible longer with 5s animation and removal timing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1626908d083329d700d5e264fb3c5