### PR TITLE
Auto-connect session and improve session tab layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -536,7 +536,9 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
 })();
 
 // ---------- Boot ----------
-(function(){ function boot(){ document.body.classList.remove('ink-on','wb-open');  syncSessionHints(); if(ROLE==='client'){ setTimeout(()=>{ const wsFilled=$('#wsUrl')?.value; if(wsFilled) connectWS(); }, 60); } }
+(function(){ function boot(){ document.body.classList.remove('ink-on','wb-open');  syncSessionHints();
+    setTimeout(()=>{ const wsFilled=$('#wsUrl')?.value; if(wsFilled) connectWS(); }, 60);
+  }
   if(document.readyState==='loading'){ document.addEventListener('DOMContentLoaded', boot, { once:true }); } else { boot(); }
 })();
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
   <header>
     <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 17c5-1 11-1 16 0" stroke="#7cd992" stroke-width="1.6" stroke-linecap="round"/><path d="M4 13c3-1 13-1 16 0" stroke="#58c4dc" stroke-width="1.6" stroke-linecap="round"/><path d="M4 9c2-1 7-1 10 0" stroke="#ffb86b" stroke-width="1.6" stroke-linecap="round"/><circle cx="6" cy="9" r="1.8" fill="#ffb86b"/><circle cx="12" cy="13" r="1.8" fill="#58c4dc"/><circle cx="18" cy="17" r="1.8" fill="#7cd992"/></svg>
     <h1 id="hostTitle">Lean Training — Live Session</h1>
-    <div id="headerClient" class="header-user hidden"></div>
-    <div id="roomBadge" class="right row mini muted">Room: <span id="roomId" class="chip mono">auto</span></div>
+    <div id="roomBadge" class="row mini muted">Room: <span id="roomId" class="chip mono">auto</span></div>
+    <div id="headerClient" class="right header-user hidden"></div>
   </header>
 
   <main>
@@ -44,7 +44,7 @@
     </section>
     <section class="card" id="participantsCard">
       <h2>Participants (<span id="participantCount">0</span>)</h2>
-      <div id="participantList" class="mt8 mini muted">No participants yet.</div>
+      <div id="participantList" class="mt8">No participants yet.</div>
     </section>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -163,6 +163,7 @@ body.ink-on canvas.whiteboard{pointer-events:auto; cursor:crosshair}
 .session-grid{display:grid;grid-template-columns:1fr;gap:12px}
 .session-warn{margin-top:8px;background:#332a12;border-color:#6b5a2a;color:#ffd18b}
 .session-note{margin:8px 0 0}
+#participantList .chip{font-size:20px;padding:8px 12px}
 
 /* Always-on mini QR (resizable) */
 .mini-qr{


### PR DESCRIPTION
## Summary
- Automatically initiate WebSocket connection on page load
- Move room badge next to session title to prevent mini QR overlap
- Enlarge participant list chips for better visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c423a79883328ec900614c73aedc