### PR TITLE
Focus editor before inserting images

### DIFF
--- a/app.js
+++ b/app.js
@@ -530,7 +530,13 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
       const f=imgInput.files[0];
       if(!f) return;
       const reader=new FileReader();
-      reader.onload=e=>document.execCommand('insertImage',false,e.target.result);
+      reader.onload=e=>{
+        const content=pages[current]?.querySelector('.content');
+        if(content){
+          content.focus();
+          document.execCommand('insertImage',false,e.target.result);
+        }
+      };
       reader.readAsDataURL(f);
       imgInput.value='';
     });


### PR DESCRIPTION
## Summary
- Ensure slide content area regains focus before inserting uploaded images so the image appears at the caret.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b20c9c34408332976968439f34e56a