### PR TITLE
Add image resize/rotation and fix layer dropdown

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,6 +124,9 @@ pre{white-space:pre-wrap;word-wrap:break-word}
 body.ink-on canvas.whiteboard{pointer-events:auto; cursor:crosshair}
 .page img.draggable{position:absolute;top:10px;left:10px;max-width:100%;cursor:move;}
 .page img.draggable.selected{outline:2px solid #2aa6ff}
+.page .img-handle{position:absolute;width:12px;height:12px;background:#2aa6ff;border:2px solid #fff;border-radius:2px;z-index:5;display:none}
+.page .img-resize{cursor:nwse-resize}
+.page .img-rotate{border-radius:999px;cursor:grab}
 
 /* FAB + toolbar */
 .fab{position:fixed;right:18px;bottom:18px;z-index:1000;background:#0f2a42;border:1px solid #1e3954;border-radius:999px;padding:12px;cursor:pointer;box-shadow:0 12px 28px rgba(0,0,0,.5);backdrop-filter:blur(6px);transition:transform .1s ease, background .2s ease}


### PR DESCRIPTION
## Summary
- allow selected images to be resized via bottom-right handle
- enable rotation of selected images with a rotation handle
- keep layer dropdown active while an image is selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e3b8552c8332957945a1802be318