### PR TITLE
fix: preserve image positions when loading

### DIFF
--- a/app.js
+++ b/app.js
@@ -521,10 +521,10 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
   function makeDraggable(img){
     img.classList.add('draggable');
     img.style.position='absolute';
-    img.style.left='10px';
-    img.style.top='10px';
-    img.dataset.layer=layerSelect?.value||'4';
-    img.style.zIndex=String((layerSelect?.value?Number(layerSelect.value)-1:3));
+    if(!img.style.left) img.style.left='10px';
+    if(!img.style.top) img.style.top='10px';
+    if(!img.dataset.layer) img.dataset.layer=layerSelect?.value||'4';
+    img.style.zIndex=String(Number(img.dataset.layer||'4')-1);
     img.draggable=false;
     img.addEventListener('pointerdown',imgDragStart);
   }


### PR DESCRIPTION
## Summary
- Avoid resetting image positions and layer info when enabling drag behaviour
- Ensure z-index matches stored layer for loaded images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b442f967dc83329b177d8e72fd0643