### PR TITLE
feat: add file menu overlay and slide nav button

### DIFF
--- a/app.js
+++ b/app.js
@@ -155,10 +155,31 @@ function syncSessionHints(){
     $$('.slide').forEach(s=>s.classList.remove('active'));
     if (tabEl){ tabEl.classList.add('active'); const target=$('#'+tabEl.dataset.tab); if(target) target.classList.add('active'); }
   }
+  function hideFileMenu(){
+    $('#fileToolbar')?.classList.add('hidden');
+    document.querySelector('.tab[data-tab="file"]')?.classList.remove('active');
+  }
   // Delegate clicks so it's robust
   document.addEventListener('click', (ev)=>{
     const t = ev.target.closest('.tab');
-    if(!t) return; ev.preventDefault(); showTab(t);
+    if(!t) return; ev.preventDefault();
+    if(t.dataset.tab==='file'){
+      const tb=$('#fileToolbar');
+      if(!tb) return;
+      if(tb.classList.contains('hidden')){
+        $$('.tab').forEach(x=>x.classList.remove('active'));
+        $$('.slide').forEach(s=>s.classList.remove('active'));
+        $('#presentation')?.classList.add('active');
+        tb.classList.remove('hidden');
+        t.classList.add('active');
+      } else {
+        hideFileMenu();
+        document.querySelector('.tab[data-tab="presentation"]')?.classList.add('active');
+      }
+      return;
+    }
+    hideFileMenu();
+    showTab(t);
   });
   // Ensure Presentation is active on load by default
   const active = document.querySelector('.tab.active');
@@ -650,8 +671,9 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
   if(nextPage) nextPage.addEventListener('click',()=>showPage(current+1));
   if(presAdd) presAdd.addEventListener('click',createBlank);
   if(presNew) presNew.addEventListener('click',()=>{ $$('#presentation .page-shell .page').forEach(p=>p.remove()); createBlank(); presName.value=''; });
-  if(presSave) presSave.addEventListener('click',save);
-  if(presLoad) presLoad.addEventListener('click',()=>{ const n=presList.value; if(n) load(n); });
+  function hideFileMenu(){ $('#fileToolbar')?.classList.add('hidden'); document.querySelector('.tab[data-tab="file"]')?.classList.remove('active'); document.querySelector('.tab[data-tab="presentation"]')?.classList.add('active'); }
+  if(presSave) presSave.addEventListener('click',()=>{ save(); hideFileMenu(); });
+  if(presLoad) presLoad.addEventListener('click',()=>{ const n=presList.value; if(n) load(n); hideFileMenu(); });
   if(moveLeft) moveLeft.addEventListener('click',()=>moveSlide(current, current-1));
   if(moveRight) moveRight.addEventListener('click',()=>moveSlide(current, current+1));
   if(buildPrev) buildPrev.addEventListener('click',()=>builds[current]?.prev());

--- a/index.html
+++ b/index.html
@@ -49,21 +49,14 @@
     </section>
   </div>
 
-  <!-- FILE TAB -->
-  <div id="file" class="slide">
-    <div class="row gap8 mb8" id="fileToolbar">
+  <!-- PRESENTATION TAB -->
+  <div id="presentation" class="slide active">
+    <div class="row gap8 mb8 hidden" id="fileToolbar">
       <input id="presName" placeholder="Presentation name" class="w160" />
       <button id="presNew" class="pill">New</button>
       <button id="presSave" class="pill">Save</button>
       <select id="presList" class="w160"></select>
       <button id="presLoad" class="pill">Load</button>
-    </div>
-  </div>
-
-  <!-- PRESENTATION TAB -->
-  <div id="presentation" class="slide active">
-    <div class="row gap8 mb8" id="presToolbar">
-      <button id="presAdd" class="pill">Add slide</button>
     </div>
     <div class="page-shell">
       <div class="row gap8 mb8" id="textToolbar">
@@ -196,6 +189,7 @@
   <button id="prevPage" class="pill ghost">◀ Prev</button>
   <div class="dots" id="pageDots"></div>
   <button id="nextPage" class="pill ghost">Next ▶</button>
+  <button id="presAdd" class="pill ghost">New slide</button>
   <button id="moveLeft" class="pill ghost">Move ◀</button>
   <button id="moveRight" class="pill ghost">Move ▶</button>
 </div>


### PR DESCRIPTION
## Summary
- Toggle presentation save/load menu via new File tab without hiding canvas
- Hide file menu after saving or loading to return focus to slides
- Move "New slide" control into slide navigation bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4498f7d308332803c9bd3c9489490