### PR TITLE
Move tabs to header with dropdown file menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -170,6 +170,8 @@ function syncSessionHints(){
         $$('.tab').forEach(x=>x.classList.remove('active'));
         $$('.slide').forEach(s=>s.classList.remove('active'));
         $('#presentation')?.classList.add('active');
+        tb.style.left = t.offsetLeft + 'px';
+        tb.style.top = (t.offsetTop + t.offsetHeight) + 'px';
         tb.classList.remove('hidden');
         t.classList.add('active');
       } else {

--- a/index.html
+++ b/index.html
@@ -7,24 +7,33 @@
   <title>Lean Training — Presenter (v7.2 resizable mini‑QR)</title>
   <link rel="stylesheet" href="./style.css" />
 </head>
-<body>
+  <body>
 <div class="wrap">
   <header>
-    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 17c5-1 11-1 16 0" stroke="#7cd992" stroke-width="1.6" stroke-linecap="round"/><path d="M4 13c3-1 13-1 16 0" stroke="#58c4dc" stroke-width="1.6" stroke-linecap="round"/><path d="M4 9c2-1 7-1 10 0" stroke="#ffb86b" stroke-width="1.6" stroke-linecap="round"/><circle cx="6" cy="9" r="1.8" fill="#ffb86b"/><circle cx="12" cy="13" r="1.8" fill="#58c4dc"/><circle cx="18" cy="17" r="1.8" fill="#7cd992"/></svg>
-    <h1 id="hostTitle">Lean Training — Live Session</h1>
-    <div id="roomBadge" class="row mini muted">Room: <span id="roomId" class="chip mono">auto</span></div>
-    <div id="headerClient" class="right header-user hidden"></div>
+    <div class="header-main">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 17c5-1 11-1 16 0" stroke="#7cd992" stroke-width="1.6" stroke-linecap="round"/><path d="M4 13c3-1 13-1 16 0" stroke="#58c4dc" stroke-width="1.6" stroke-linecap="round"/><path d="M4 9c2-1 7-1 10 0" stroke="#ffb86b" stroke-width="1.6" stroke-linecap="round"/><circle cx="6" cy="9" r="1.8" fill="#ffb86b"/><circle cx="12" cy="13" r="1.8" fill="#58c4dc"/><circle cx="18" cy="17" r="1.8" fill="#7cd992"/></svg>
+      <h1 id="hostTitle">Lean Training — Live Session</h1>
+      <div id="roomBadge" class="row mini muted">Room: <span id="roomId" class="chip mono">auto</span></div>
+      <div id="headerClient" class="right header-user hidden"></div>
+    </div>
+    <div class="tabs" role="tablist">
+      <div class="tab" data-tab="file">File</div>
+      <div class="tab" data-tab="session">Session</div>
+      <div class="tab active" data-tab="presentation">Presentation</div>
+      <div class="tab" data-tab="polls">Polls</div>
+      <div class="tab" data-tab="leader">Leaderboard</div>
+    </div>
+    <div class="row gap8 hidden file-menu" id="fileToolbar">
+      <input id="presName" placeholder="Presentation name" class="w160" />
+      <button id="presNew" class="pill">New</button>
+      <button id="presSave" class="pill">Save</button>
+      <select id="presList" class="w160"></select>
+      <button id="presLoad" class="pill">Load</button>
+    </div>
   </header>
 
   <main>
     <section id="slidesCard" class="card">
-      <div class="tabs" role="tablist">
-        <div class="tab" data-tab="file">File</div>
-        <div class="tab" data-tab="session">Session</div>
-        <div class="tab active" data-tab="presentation">Presentation</div>
-        <div class="tab" data-tab="polls">Polls</div>
-        <div class="tab" data-tab="leader">Leaderboard</div>
-      </div>
 
     <!-- SESSION TAB -->
   <div id="session" class="slide">
@@ -51,13 +60,6 @@
 
   <!-- PRESENTATION TAB -->
   <div id="presentation" class="slide active">
-    <div class="row gap8 mb8 hidden" id="fileToolbar">
-      <input id="presName" placeholder="Presentation name" class="w160" />
-      <button id="presNew" class="pill">New</button>
-      <button id="presSave" class="pill">Save</button>
-      <select id="presList" class="w160"></select>
-      <button id="presLoad" class="pill">Load</button>
-    </div>
     <div class="page-shell">
       <div class="row gap8 mb8" id="textToolbar">
         <select id="fontSelect">

--- a/style.css
+++ b/style.css
@@ -16,12 +16,14 @@ footer{padding:10px 0 18px}
 .wrap{display:grid;grid-template-rows:auto 1fr auto;min-height:100%}
 
 /* Header */
-header{display:flex;align-items:center;gap:16px;padding:14px 18px;border-bottom:1px solid #1e2a39;background:linear-gradient(180deg,#0f1622,#0c111a)}
+header{display:flex;flex-direction:column;gap:8px;padding:14px 18px;border-bottom:1px solid #1e2a39;background:linear-gradient(180deg,#0f1622,#0c111a);position:relative}
+.header-main{display:flex;align-items:center;gap:16px}
 header h1{font-size:18px;margin:0;letter-spacing:.3px}
 header .badge{font-size:12px;background:var(--chip);padding:4px 8px;border-radius:999px;color:var(--muted)}
 .header-user{display:flex;align-items:center;gap:8px;font-size:20px}
 .header-user .emoji{font-size:28px}
 .header-user .name{font-weight:600;font-size:20px}
+.file-menu{background:#0f1520;border:1px solid #1e2a39;border-radius:12px;padding:8px;gap:8px;position:absolute;top:100%;left:0;z-index:1000}
 
 /* Layout */
 main{padding:18px;display:grid;gap:18px}


### PR DESCRIPTION
## Summary
- Relocate tab controls into the header for more editing space
- Add dropdown file menu that appears when File tab is toggled
- Style header and file menu for new layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b44da8b9c88332813a7a736adf1f69