### PR TITLE
Fix drawing toolbar color picker and highlighter transparency

### DIFF
--- a/app.js
+++ b/app.js
@@ -566,6 +566,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
         if(curr){ page._wb.strokes.push(curr); page._wb.redo=[]; }
         curr=null;
         ctx.globalAlpha=1; ctx.globalCompositeOperation='source-over';
+        redrawWB(page);
       }
       c.addEventListener('pointerup',end);
       c.addEventListener('pointerleave',end);
@@ -778,8 +779,9 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
     wbFab.addEventListener('click',()=>{ const on=document.body.classList.toggle('ink-on'); document.body.classList.toggle('wb-open'); wbFab.classList.toggle('active',on); wbIndicator?.classList.toggle('on',on); });
   }
   if(wbColorSwatch && wbColorInput){
-    wbColorSwatch.addEventListener('click',()=>wbColorInput.click());
-    wbColorInput.addEventListener('input',()=>{ wbColor=wbColorInput.value; wbColorSwatch.style.background=wbColor; });
+    function setWbColor(){ wbColor=wbColorInput.value; wbColorSwatch.style.background=wbColor; }
+    wbColorInput.addEventListener('input', setWbColor);
+    wbColorInput.addEventListener('change', setWbColor);
   }
   if(wbSizeSeg){
     wbSizeSeg.addEventListener('click',e=>{ const b=e.target.closest('button[data-size]'); if(!b) return; wbSizeVal=Number(b.dataset.size); wbSizeSeg.querySelectorAll('button').forEach(x=>x.classList.remove('active')); b.classList.add('active'); });

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
 <div id="wbPanel" class="wb-panel">
   <div class="row">
     <label>Color</label>
-    <div id="wbColorSwatch" class="color-swatch" style="background:#7cd992"></div>
+    <label id="wbColorSwatch" for="wbColor" class="color-swatch" style="background:#7cd992"></label>
     <input type="color" id="wbColor" value="#7cd992" class="color-hidden" />
   </div>
   <div class="row mt8">
@@ -219,6 +219,7 @@
       <button data-size="2"><span class="size-dot" style="width:4px;height:4px"></span></button>
       <button data-size="4" class="active"><span class="size-dot" style="width:8px;height:8px"></span></button>
       <button data-size="8"><span class="size-dot" style="width:12px;height:12px"></span></button>
+      <button data-size="16"><span class="size-dot" style="width:20px;height:20px"></span></button>
     </div>
   </div>
   <div class="row mt8">

--- a/style.css
+++ b/style.css
@@ -139,7 +139,7 @@ body.ink-on canvas.whiteboard{pointer-events:auto; cursor:crosshair}
 .wb-open .wb-panel{display:block}
 .wb-panel .row{gap:8px}
 .wb-panel label{font-size:12px;color:#b9c7d6}
-.color-swatch{width:28px;height:28px;border-radius:999px;border:2px solid #274b6b;box-shadow:0 2px 8px rgba(0,0,0,.4);cursor:pointer}
+.color-swatch{width:28px;height:28px;border-radius:999px;border:2px solid #274b6b;box-shadow:0 2px 8px rgba(0,0,0,.4);cursor:pointer;display:inline-block}
 .color-hidden{position:absolute;left:-9999px;opacity:0;width:0;height:0}
 .swatch{width:20px;height:20px;border-radius:999px;border:2px solid #274b6b;cursor:pointer}
 .swatchwrap{display:flex;gap:8px;align-items:center;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- Make color picker swatch a label and update color on input/change
- Add larger brush size option for broader strokes
- Redraw canvas after strokes to keep highlighter transparent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a71cc2348332b6dbf5b7af3934a1