### PR TITLE
Improve whiteboard color selection and layering

### DIFF
--- a/app.js
+++ b/app.js
@@ -492,7 +492,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
   const fontSelect=$('#fontSelect'), fontSize=$('#fontSize'), fontColor=$('#fontColor'), imgBtn=$('#imgBtn'), imgInput=$('#imgInput');
   const moveLeft=$('#moveLeft'), moveRight=$('#moveRight');
   const layerSelect=$('#imgLayer');
-  const wbFab=$('#wbFab'), wbColorInput=$('#wbColor'), wbColorSwatch=$('#wbColorSwatch'), wbSizeSeg=$('#wbSize'), wbClear=$('#wbClear'), wbIndicator=$('#wbIndicator'), wbToolSeg=$('#wbTool'), wbUndo=$('#wbUndo'), wbRedo=$('#wbRedo');
+  const wbFab=$('#wbFab'), wbColorInput=$('#wbColor'), wbColorSwatch=$('#wbColorSwatch'), wbColorSeg=$('#wbColors'), wbSizeSeg=$('#wbSize'), wbClear=$('#wbClear'), wbIndicator=$('#wbIndicator'), wbToolSeg=$('#wbTool'), wbUndo=$('#wbUndo'), wbRedo=$('#wbRedo');
 
   let pages=[], builds=[], current=0;
   let selectedImg=null;
@@ -778,8 +778,12 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
   if(wbFab){
     wbFab.addEventListener('click',()=>{ const on=document.body.classList.toggle('ink-on'); document.body.classList.toggle('wb-open'); wbFab.classList.toggle('active',on); wbIndicator?.classList.toggle('on',on); });
   }
+  if(wbColorSeg){
+    wbColorSeg.addEventListener('click',e=>{ const b=e.target.closest('button[data-color]'); if(!b) return; wbColor=b.dataset.color; wbColorInput.value=wbColor; wbColorSeg.querySelectorAll('button').forEach(x=>x.classList.remove('active')); b.classList.add('active'); });
+  }
   if(wbColorSwatch && wbColorInput){
-    function setWbColor(){ wbColor=wbColorInput.value; wbColorSwatch.style.background=wbColor; }
+    wbColorSwatch.addEventListener('click',()=>wbColorInput.click());
+    function setWbColor(){ wbColor=wbColorInput.value; wbColorSwatch.style.background=wbColor; wbColorSeg?.querySelectorAll('button').forEach(x=>x.classList.remove('active')); wbColorSwatch.classList.add('active'); }
     wbColorInput.addEventListener('input', setWbColor);
     wbColorInput.addEventListener('change', setWbColor);
   }

--- a/index.html
+++ b/index.html
@@ -202,7 +202,14 @@
 <div id="wbPanel" class="wb-panel">
   <div class="row">
     <label>Color</label>
-    <label id="wbColorSwatch" for="wbColor" class="color-swatch" style="background:#7cd992"></label>
+    <div id="wbColors" class="row gap6">
+      <button class="color-swatch active" data-color="#7cd992" style="background:#7cd992"></button>
+      <button class="color-swatch" data-color="#58c4dc" style="background:#58c4dc"></button>
+      <button class="color-swatch" data-color="#ffb86b" style="background:#ffb86b"></button>
+      <button class="color-swatch" data-color="#f25f5c" style="background:#f25f5c"></button>
+      <button class="color-swatch" data-color="#000000" style="background:#000000"></button>
+      <button id="wbColorSwatch" class="color-swatch" title="Custom color" style="background:#7cd992"></button>
+    </div>
     <input type="color" id="wbColor" value="#7cd992" class="color-hidden" />
   </div>
   <div class="row mt8">

--- a/style.css
+++ b/style.css
@@ -122,7 +122,7 @@ pre{white-space:pre-wrap;word-wrap:break-word}
 .dot.active{background:#54b6cf}
 .page{position:relative;background:#0c121a;border:1px solid #1b2635;border-radius:18px;min-height:520px;padding:12px;overflow:hidden}
 .page .content{position:relative;z-index:1}
-.page canvas.whiteboard{position:absolute;inset:0;z-index:2; pointer-events:none;}
+.page canvas.whiteboard{position:absolute;inset:0;z-index:6; pointer-events:none;}
 /* Drawing cursor and pointer activation only when ON */
 body.ink-on canvas.whiteboard{pointer-events:auto; cursor:crosshair}
 .page img.draggable{position:absolute;top:10px;left:10px;max-width:100%;cursor:move;}
@@ -139,7 +139,8 @@ body.ink-on canvas.whiteboard{pointer-events:auto; cursor:crosshair}
 .wb-open .wb-panel{display:block}
 .wb-panel .row{gap:8px}
 .wb-panel label{font-size:12px;color:#b9c7d6}
-.color-swatch{width:28px;height:28px;border-radius:999px;border:2px solid #274b6b;box-shadow:0 2px 8px rgba(0,0,0,.4);cursor:pointer;display:inline-block}
+.color-swatch{width:28px;height:28px;border-radius:999px;border:2px solid #274b6b;box-shadow:0 2px 8px rgba(0,0,0,.4);cursor:pointer;display:inline-block;padding:0}
+.color-swatch.active{border-color:#fff}
 .color-hidden{position:absolute;left:-9999px;opacity:0;width:0;height:0}
 .swatch{width:20px;height:20px;border-radius:999px;border:2px solid #274b6b;cursor:pointer}
 .swatchwrap{display:flex;gap:8px;align-items:center;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- Add preset color buttons plus custom color picker for the whiteboard
- Raise whiteboard canvas to highest layer so drawings overlay images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4aea1dc80833288df21d73aee08c3