### PR TITLE
Add textbox background and delete controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
           <option value="7">Huge</option>
         </select>
         <input type="color" id="fontColor" />
+        <input type="color" id="textBg" value="#ffffff" disabled />
         <button id="imgBtn" class="pill">Insert Image</button>
         <button id="textBtn" class="pill">Insert Textbox</button>
         <input type="file" id="imgInput" accept="image/*" class="hidden" />
@@ -84,6 +85,7 @@
           <option value="4" selected>Layer 4</option>
           <option value="5">Layer 5</option>
         </select>
+        <button id="deleteBtn" class="pill" disabled>Delete</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Allow editing textbox background color
- Remove the immovable default textbox
- Make images and textboxes deletable via button or Delete key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5793c594483328d324d75ea063fc6