### PR TITLE
Fix custom color picker in drawing toolbar

### DIFF
--- a/app.js
+++ b/app.js
@@ -504,7 +504,15 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
 
   function initColorPicker(input, swatch, onChange){
     if(!input || !swatch) return;
-    swatch.addEventListener('click', ()=>input.click());
+    swatch.addEventListener('click', ()=>{
+      if (typeof input.showPicker === 'function') {
+        try { input.showPicker(); }
+        catch(_){ input.click(); }
+      }
+      else {
+        input.click();
+      }
+    });
     function sync(){ swatch.style.background=input.value; onChange?.(input.value); }
     input.addEventListener('input', sync);
     input.addEventListener('change', sync);


### PR DESCRIPTION
## Summary
- Ensure whiteboard custom color swatch opens the browser color dialog
- Fall back to traditional `click()` when `showPicker()` is unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b62950888332902590fa7bfc1999