### PR TITLE
Fix custom color picker activation in whiteboard toolbar

### DIFF
--- a/app.js
+++ b/app.js
@@ -504,15 +504,18 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
 
   function initColorPicker(input, swatch, onChange){
     if(!input || !swatch) return;
-    swatch.addEventListener('click', ()=>{
-      if (typeof input.showPicker === 'function') {
-        try { input.showPicker(); }
-        catch(_){ input.click(); }
-      }
-      else {
-        input.click();
-      }
-    });
+    const isLabel = swatch.tagName === 'LABEL' && swatch.getAttribute('for') === input.id;
+    if(!isLabel){
+      swatch.addEventListener('click', ()=>{
+        if (typeof input.showPicker === 'function') {
+          try { input.showPicker(); }
+          catch(_){ input.click(); }
+        }
+        else {
+          input.click();
+        }
+      });
+    }
     function sync(){ swatch.style.background=input.value; onChange?.(input.value); }
     input.addEventListener('input', sync);
     input.addEventListener('change', sync);
@@ -866,9 +869,9 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
     wbFab.addEventListener('click',()=>{ const on=document.body.classList.toggle('ink-on'); document.body.classList.toggle('wb-open'); wbFab.classList.toggle('active',on); wbIndicator?.classList.toggle('on',on); });
   }
   if(wbColorSeg){
-    wbColorSeg.addEventListener('click',e=>{ const b=e.target.closest('button[data-color]'); if(!b) return; wbColor=b.dataset.color; wbColorInput.value=wbColor; wbColorSeg.querySelectorAll('button').forEach(x=>x.classList.remove('active')); b.classList.add('active'); });
+    wbColorSeg.addEventListener('click',e=>{ const b=e.target.closest('button[data-color]'); if(!b) return; wbColor=b.dataset.color; wbColorInput.value=wbColor; wbColorSeg.querySelectorAll('button,label').forEach(x=>x.classList.remove('active')); b.classList.add('active'); });
   }
-  initColorPicker(wbColorInput, wbColorSwatch, c=>{ wbColor=c; wbColorSeg?.querySelectorAll('button').forEach(x=>x.classList.remove('active')); wbColorSwatch.classList.add('active'); });
+  initColorPicker(wbColorInput, wbColorSwatch, c=>{ wbColor=c; wbColorSeg?.querySelectorAll('button,label').forEach(x=>x.classList.remove('active')); wbColorSwatch.classList.add('active'); });
   if(wbSizeSeg){
     wbSizeSeg.addEventListener('click',e=>{ const b=e.target.closest('button[data-size]'); if(!b) return; wbSizeVal=Number(b.dataset.size); wbSizeSeg.querySelectorAll('button').forEach(x=>x.classList.remove('active')); b.classList.add('active'); });
   }

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
       <button class="color-swatch" data-color="#ffb86b" style="background:#ffb86b"></button>
       <button class="color-swatch" data-color="#f25f5c" style="background:#f25f5c"></button>
       <button class="color-swatch" data-color="#000000" style="background:#000000"></button>
-      <button id="wbColorSwatch" class="color-swatch" title="Custom color" style="background:#7cd992"></button>
+      <label id="wbColorSwatch" for="wbColor" class="color-swatch" title="Custom color" style="background:#7cd992"></label>
     </div>
     <input type="color" id="wbColor" value="#7cd992" class="color-hidden" />
   </div>


### PR DESCRIPTION
## Summary
- Replace custom color button with label bound to hidden color input
- Skip JS click binding when swatch is a label to avoid duplicate picker calls
- Ensure active class handling includes label swatch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b7a665988332813021f3bee18382