### PR TITLE
Refactor header and simplify presentation shell

### DIFF
--- a/app.js
+++ b/app.js
@@ -483,7 +483,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
 // ---------- Builds (step-by-step) ----------
 // ---------- Presentation builder ----------
 (function(){
-  const shell = document.querySelector('#presentation .page-shell');
+  const shell = document.querySelector('#presentation');
   if(!shell) return;
 
   const prevPage=$('#prevPage'), nextPage=$('#nextPage'), pageDots=$('#pageDots');
@@ -741,7 +741,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
   }
 
   function refreshPages(){
-    pages=$$('#presentation .page-shell .page');
+    pages=$$('#presentation .page');
     pages.forEach(p=>ensureWBCanvas(p));
     builds=pages.map(p=>BuildState(p));
     updateDots();
@@ -792,7 +792,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
 
   async function save(){ const name=(presName?.value||'').trim(); if(!name){ toast('Name required'); return; } try{ await fetch('/api/presentations/'+encodeURIComponent(name), { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(gather()) }); loadList(); toast('Saved'); }catch(_){ toast('Save failed'); } }
 
-  async function load(name){ try{ const res=await fetch('/api/presentations/'+encodeURIComponent(name)); if(!res.ok) return; const data=await res.json(); $$('#presentation .page-shell .page').forEach(p=>p.remove()); (data.slides||[]).forEach(s=>{ const page=document.createElement('div'); page.className='page'; page.innerHTML=s.html||''; const content=page.querySelector('.content'); if(content) content.contentEditable='true'; page.querySelectorAll('.draggable').forEach(makeDraggable); ensureWBCanvas(page); shell.appendChild(page); if(page._wb){ page._wb.strokes = s.wb || []; page._wb.redo = []; redrawWB(page); } }); refreshPages(); showPage(0); presName.value=name; }catch(_){ toast('Load failed'); } }
+  async function load(name){ try{ const res=await fetch('/api/presentations/'+encodeURIComponent(name)); if(!res.ok) return; const data=await res.json(); $$('#presentation .page').forEach(p=>p.remove()); (data.slides||[]).forEach(s=>{ const page=document.createElement('div'); page.className='page'; page.innerHTML=s.html||''; const content=page.querySelector('.content'); if(content) content.contentEditable='true'; page.querySelectorAll('.draggable').forEach(makeDraggable); ensureWBCanvas(page); shell.appendChild(page); if(page._wb){ page._wb.strokes = s.wb || []; page._wb.redo = []; redrawWB(page); } }); refreshPages(); showPage(0); presName.value=name; }catch(_){ toast('Load failed'); } }
 
   async function loadList(){ try{ const res=await fetch('/api/presentations'); if(!res.ok) return; const arr=await res.json(); if(presList){ presList.innerHTML='<option value="">(choose)</option>'+arr.map(n=>`<option value="${n}">${n}</option>`).join(''); } }catch(_){ /* noop */ } }
 
@@ -800,7 +800,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
   if(nextPage) nextPage.addEventListener('click',()=>showPage(current+1));
   if(presAdd) presAdd.addEventListener('click',createBlank);
   if(presDup) presDup.addEventListener('click',()=>duplicateSlide(current));
-  if(presNew) presNew.addEventListener('click',()=>{ $$('#presentation .page-shell .page').forEach(p=>p.remove()); createBlank(); presName.value=''; });
+  if(presNew) presNew.addEventListener('click',()=>{ $$('#presentation .page').forEach(p=>p.remove()); createBlank(); presName.value=''; });
   if(presSave) presSave.addEventListener('click',()=>{ save(); hideFileMenu(); });
   if(presLoad) presLoad.addEventListener('click',()=>{ const n=presList.value; if(n) load(n); hideFileMenu(); });
   if(moveLeft) moveLeft.addEventListener('click',()=>moveSlide(current, current-1));

--- a/index.html
+++ b/index.html
@@ -10,12 +10,6 @@
   <body>
 <div class="wrap">
   <header>
-    <div class="header-main">
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 17c5-1 11-1 16 0" stroke="#7cd992" stroke-width="1.6" stroke-linecap="round"/><path d="M4 13c3-1 13-1 16 0" stroke="#58c4dc" stroke-width="1.6" stroke-linecap="round"/><path d="M4 9c2-1 7-1 10 0" stroke="#ffb86b" stroke-width="1.6" stroke-linecap="round"/><circle cx="6" cy="9" r="1.8" fill="#ffb86b"/><circle cx="12" cy="13" r="1.8" fill="#58c4dc"/><circle cx="18" cy="17" r="1.8" fill="#7cd992"/></svg>
-      <h1 id="hostTitle">Lean Training — Live Session</h1>
-      <div id="roomBadge" class="row mini muted">Room: <span id="roomId" class="chip mono">auto</span></div>
-      <div id="headerClient" class="right header-user hidden"></div>
-    </div>
     <div class="tabs" role="tablist">
       <div class="tab" data-tab="file">File</div>
       <div class="tab" data-tab="session">Session</div>
@@ -23,6 +17,37 @@
       <div class="tab" data-tab="polls">Polls</div>
       <div class="tab" data-tab="leader">Leaderboard</div>
     </div>
+    <div class="header-sep"></div>
+    <div class="row gap8" id="textToolbar">
+      <select id="fontSelect">
+        <option value="Arial">Arial</option>
+        <option value="'Times New Roman'">Times New Roman</option>
+        <option value="'Courier New'">Courier New</option>
+      </select>
+      <select id="fontSize">
+        <option value="1">Small</option>
+        <option value="3" selected>Normal</option>
+        <option value="5">Large</option>
+        <option value="7">Huge</option>
+      </select>
+      <button id="fontColorSwatch" class="color-swatch" title="Text color" style="background:#000000"></button>
+      <button id="textBgSwatch" class="color-swatch" title="Textbox background color" style="background:#ffffff" disabled></button>
+      <input type="color" id="fontColor" value="#000000" class="color-hidden" />
+      <input type="color" id="textBg" value="#ffffff" class="color-hidden" disabled />
+      <button id="textBgTransparent" class="pill" disabled>Transparent</button>
+      <button id="imgBtn" class="pill" title="Insert Image">🖼️</button>
+      <button id="textBtn" class="pill" title="Insert Textbox">📝</button>
+      <input type="file" id="imgInput" accept="image/*" class="hidden" />
+      <select id="imgLayer" disabled>
+        <option value="1">Layer 1</option>
+        <option value="2">Layer 2</option>
+        <option value="3">Layer 3</option>
+        <option value="4" selected>Layer 4</option>
+        <option value="5">Layer 5</option>
+      </select>
+      <button id="deleteBtn" class="pill" disabled title="Delete">🗑️</button>
+    </div>
+    <div id="roomBadge" class="row mini muted right">Room: <span id="roomId" class="chip mono">auto</span></div>
     <div class="row gap8 hidden file-menu" id="fileToolbar">
       <input id="presName" placeholder="Presentation name" class="w160" />
       <button id="presNew" class="pill">New</button>
@@ -59,39 +84,7 @@
   </div>
 
   <!-- PRESENTATION TAB -->
-  <div id="presentation" class="slide active">
-    <div class="page-shell">
-      <div class="row gap8 mb8" id="textToolbar">
-        <select id="fontSelect">
-          <option value="Arial">Arial</option>
-          <option value="'Times New Roman'">Times New Roman</option>
-          <option value="'Courier New'">Courier New</option>
-        </select>
-        <select id="fontSize">
-          <option value="1">Small</option>
-          <option value="3" selected>Normal</option>
-          <option value="5">Large</option>
-          <option value="7">Huge</option>
-        </select>
-        <button id="fontColorSwatch" class="color-swatch" title="Text color" style="background:#000000"></button>
-        <button id="textBgSwatch" class="color-swatch" title="Textbox background color" style="background:#ffffff" disabled></button>
-        <input type="color" id="fontColor" value="#000000" class="color-hidden" />
-        <input type="color" id="textBg" value="#ffffff" class="color-hidden" disabled />
-        <button id="textBgTransparent" class="pill" disabled>Transparent</button>
-        <button id="imgBtn" class="pill">Insert Image</button>
-        <button id="textBtn" class="pill">Insert Textbox</button>
-        <input type="file" id="imgInput" accept="image/*" class="hidden" />
-        <select id="imgLayer" disabled>
-          <option value="1">Layer 1</option>
-          <option value="2">Layer 2</option>
-          <option value="3">Layer 3</option>
-          <option value="4" selected>Layer 4</option>
-          <option value="5">Layer 5</option>
-        </select>
-        <button id="deleteBtn" class="pill" disabled>Delete</button>
-      </div>
-    </div>
-  </div>
+  <div id="presentation" class="slide active"></div>
 
   <!-- POLLS (host) -->
   <div id="polls" class="slide">

--- a/style.css
+++ b/style.css
@@ -16,10 +16,8 @@ footer{padding:10px 0 18px}
 .wrap{display:grid;grid-template-rows:auto 1fr auto;min-height:100%}
 
 /* Header */
-header{display:flex;flex-direction:column;gap:8px;padding:14px 18px;border-bottom:1px solid #1e2a39;background:linear-gradient(180deg,#0f1622,#0c111a);position:relative}
-.header-main{display:flex;align-items:center;gap:16px}
-header h1{font-size:18px;margin:0;letter-spacing:.3px}
-header .badge{font-size:12px;background:var(--chip);padding:4px 8px;border-radius:999px;color:var(--muted)}
+header{display:flex;align-items:center;gap:8px;padding:14px 18px;border-bottom:1px solid #1e2a39;background:linear-gradient(180deg,#0f1622,#0c111a);position:relative}
+.header-sep{width:1px;height:32px;background:#1e2a39;margin:0 8px}
 .header-user{display:flex;align-items:center;gap:8px;font-size:20px}
 .header-user .emoji{font-size:28px}
 .header-user .name{font-weight:600;font-size:20px}
@@ -34,6 +32,7 @@ main{padding:18px;display:grid;gap:18px}
 /* Cards */
 .card{background:linear-gradient(180deg,#0f1520,#0c121a);border:1px solid #1b2635;border-radius:18px;box-shadow:0 8px 20px rgba(0,0,0,.25);padding:16px}
 .card h2{margin:.2rem 0 0.6rem;font-size:16px;letter-spacing:.2px}
+#slidesCard{padding:8px}
 
 /* Typo & helpers */
 .muted{color:var(--muted)}
@@ -114,7 +113,6 @@ details summary{cursor:pointer;color:#9ac6ff}
 pre{white-space:pre-wrap;word-wrap:break-word}
 
 /* Pages & whiteboard */
-.page-shell{position:relative}
 .pages-nav{display:flex;align-items:center;gap:8px;position:fixed;bottom:18px;left:18px;opacity:.2;z-index:1000}
 .pages-nav:hover{opacity:1}
 .dots{display:flex;gap:6px}


### PR DESCRIPTION
## Summary
- Streamline header to a single row with tabs, text tools, and room badge
- Replace text tool buttons with icons and reduce slide card padding
- Remove presentation page shell and adjust JavaScript to target slides directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ef4048b4833290d6d11c12b0e01e