### PR TITLE
Fix color swatch click handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -515,12 +515,7 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
     if(!isLabel){
       swatch.addEventListener('click', e=>{
         e.preventDefault();
-        if (typeof input.showPicker === 'function') {
-          const res = input.showPicker();
-          if(res && typeof res.catch === 'function') res.catch(()=>input.click());
-        } else {
-          input.click();
-        }
+        input.click();
       });
     }
     function sync(){

--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
       <button class="color-swatch" data-color="#ffb86b" style="background:#ffb86b"></button>
       <button class="color-swatch" data-color="#f25f5c" style="background:#f25f5c"></button>
       <button class="color-swatch" data-color="#000000" style="background:#000000"></button>
-      <label id="wbColorSwatch" for="wbColor" class="color-swatch" title="Custom color" style="background:#7cd992"></label>
+      <button id="wbColorSwatch" class="color-swatch" title="Custom color" style="background:#7cd992"></button>
     </div>
     <input type="color" id="wbColor" value="#7cd992" class="color-hidden" />
   </div>


### PR DESCRIPTION
## Summary
- Restore button-based custom color swatch for the whiteboard
- Simplify color picker init to directly trigger input clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b660110ba08332bb0d5b952064c5b4