### PR TITLE
feat: persist polls on server

### DIFF
--- a/app.js
+++ b/app.js
@@ -287,7 +287,7 @@ function connectWS(){ const url=$('#wsUrl')?.value?.trim(); if(!url) return toas
   const sendBtn = $('#sendPoll');
   if(sendBtn) sendBtn.addEventListener('click',()=>{ const poll=buildPoll(); if(!poll) return; startSaved(poll); });
   const saveBtn = $('#savePoll');
-  if(saveBtn) saveBtn.addEventListener('click',()=>{ const poll=buildPoll(); if(!poll) return; SavedPolls.savePoll(poll); SavedPolls.renderSavedPolls($('#savedList'), startSaved); toast('Poll saved'); });
+  if(saveBtn) saveBtn.addEventListener('click', async ()=>{ const poll=buildPoll(); if(!poll) return; await SavedPolls.savePoll(poll); await SavedPolls.renderSavedPolls($('#savedList'), startSaved); toast('Poll saved'); });
   SavedPolls.renderSavedPolls($('#savedList'), startSaved);
 })();
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -64,3 +64,25 @@ test('presentation save and load', async () => {
   const file = path.join(__dirname, '..', 'presentations', 'testpres.json');
   if (fs.existsSync(file)) fs.unlinkSync(file);
 });
+
+test('poll save and load', async () => {
+  const poll = { id: 'testpoll', q: 'Example?', type: 'tf', choices: null, timed: 0, correct: null, multi: false, allowChange: false, maxWords: 3, maxChars: 120, score: false };
+  const saveRes = await fetch(`http://localhost:${PORT}/api/polls/${poll.id}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(poll)
+  });
+  assert.strictEqual(saveRes.status, 200);
+
+  const loadRes = await fetch(`http://localhost:${PORT}/api/polls/${poll.id}`);
+  assert.strictEqual(loadRes.status, 200);
+  const loaded = await loadRes.json();
+  assert.strictEqual(loaded.q, 'Example?');
+
+  const listRes = await fetch(`http://localhost:${PORT}/api/polls`);
+  const list = await listRes.json();
+  assert.ok(list.includes('testpoll'));
+
+  const file = path.join(__dirname, '..', 'polls', 'testpoll.json');
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+});


### PR DESCRIPTION
## Summary
- Save polls on the server in a new `polls` directory with GET/POST/DELETE API endpoints
- Switch client poll saving to use the new API, fetching poll data when rendering saved polls
- Adjust UI and tests for asynchronous poll persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6649907dc8332bbecd765471d7397