### PR TITLE
fix: ensure textbox bg picker opens

### DIFF
--- a/app.js
+++ b/app.js
@@ -515,7 +515,10 @@ $('#qaSend')?.addEventListener('click',()=>{ const txt = $('#qaInput').value.tri
     if(!isLabel){
       swatch.addEventListener('click', e=>{
         e.preventDefault();
+        const wasDisabled = input.disabled;
+        if(wasDisabled) input.disabled = false;
         input.click();
+        if(wasDisabled) input.disabled = true;
       });
     }
     function sync(){


### PR DESCRIPTION
## Summary
- handle disabled color inputs when clicking swatch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93e0091448332bf187bdd9f803000